### PR TITLE
🩹fix: 카드이름 글자 길어질때 두줄로 만들기#69

### DIFF
--- a/src/components/analysis/CardRecommend.vue
+++ b/src/components/analysis/CardRecommend.vue
@@ -187,12 +187,14 @@ function formatCurrency(val) {
 }
 .card-name {
   margin-top: 0.5rem;
-  font-size: 0.65rem;
+  font-size: 0.6rem;      
+  line-height: 1.2;
   text-align: center;
-  white-space: nowrap;
+  white-space: normal;     
+  word-break: keep-all;   
   overflow: hidden;
-  text-overflow: ellipsis;
 }
+
 .btn {
   margin-top: 0.5rem;
   padding: 0.25rem 0.75rem;


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #69

## 📝작업 내용
> 🩹fix: 카드이름 글자 길어질때 두줄로 만들기#69

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
